### PR TITLE
Branching API - initial draft

### DIFF
--- a/experimental/framework/fluid-llm/package.json
+++ b/experimental/framework/fluid-llm/package.json
@@ -113,6 +113,8 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.44.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
+		"@fluidframework/id-compressor": "workspace:~",
+		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/tinylicious-client": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/experimental/framework/fluid-llm/src/branching/index.ts
+++ b/experimental/framework/fluid-llm/src/branching/index.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { TreeView, ImplicitFieldSchema } from "@fluidframework/tree";
+import {
+	getViewForForkedBranch,
+	type SchematizingSimpleTreeView,
+	type ITreeCheckoutFork,
+} from "@fluidframework/tree/internal";
+
+const viewToCheckoutMap = new Map<TreeView<ImplicitFieldSchema>, ITreeCheckoutFork>();
+
+/**
+ * Creates a branch from the given tree view.
+ * @param treeView - The tree view to branch from
+ *
+ * @remarks Right now it only supports
+ */
+export function branch<T extends ImplicitFieldSchema>(treeView: TreeView<T>): TreeView<T> {
+	const { forkView, forkCheckout } = getViewForForkedBranch(
+		treeView as SchematizingSimpleTreeView<T>,
+	);
+
+	// NOTE: this currently has the limitation that a given tree view can only have one fork at a time.
+	// How would we allow users to discard a fork they don't want anymore but still tell us, so we can clean up here?
+	if (viewToCheckoutMap.has(forkView)) {
+		throw new Error("A fork already exists for this tree view. Merge it before creating a new one.");
+	}
+	viewToCheckoutMap.set(forkView, forkCheckout);
+	return forkView;
+}
+
+/**
+ * Merges the changes from a forked tree view into the original tree view that the fork came from.
+ * @param forkedTreeView - The tree view with the changes to be merged.
+ * This must be the same view that was returned by {@link branch}.
+ * @param originalTreeView - The tree view to merge into.
+ * This must be the same view that was passed to {@link branch} to create the fork.
+ */
+export function merge<T extends ImplicitFieldSchema>(
+	forkedTreeView: TreeView<T>,
+	originalTreeView: TreeView<T>,
+): void {
+	const forkCheckout = viewToCheckoutMap.get(forkedTreeView);
+	if (forkCheckout === undefined) {
+		throw new Error("The forked tree view was not passed to the branch() function first.");
+	}
+	(originalTreeView as unknown as SchematizingSimpleTreeView<T>).checkout.merge(forkCheckout);
+	// TODO: should we delete the map entry here? Probably yes?
+	viewToCheckoutMap.delete(forkedTreeView);
+}

--- a/experimental/framework/fluid-llm/src/test/branching/index.spec.ts
+++ b/experimental/framework/fluid-llm/src/test/branching/index.spec.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { createIdCompressor } from "@fluidframework/id-compressor/internal";
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+import {
+	SchemaFactory,
+	TreeViewConfiguration,
+	SharedTree,
+} from "@fluidframework/tree/internal";
+
+import { branch, merge } from "../../branching/index.js";
+
+class MockSharedTreeRuntime extends MockFluidDataStoreRuntime {
+	public constructor() {
+		super({
+			idCompressor: createIdCompressor(),
+			registry: [SharedTree.getFactory()],
+		});
+	}
+}
+
+describe.only("branching", () => {
+	it("correct behavior", () => {
+		const sb = new SchemaFactory("test");
+		class TestNode extends sb.object("root", {
+			prop1: sb.optional(sb.number),
+			prop2: sb.optional(sb.number),
+			prop3: sb.optional(sb.number),
+		}) {}
+
+		const sharedTree = SharedTree.create(new MockSharedTreeRuntime());
+
+		const originalView = sharedTree.viewWith(new TreeViewConfiguration({ schema: TestNode }));
+		originalView.initialize({ prop1: 1, prop2: 2 });
+
+		const forkedView = branch(originalView);
+
+		// The implementation details of the kinds of changes that can happen inside the tree are not exposed at this layer.
+		// But since we know them, try to cover all of them.
+		forkedView.root.prop1 = 2; // Replace
+		forkedView.root.prop2 = undefined; // Detach
+		forkedView.root.prop3 = 3; // Attach
+
+		// Validate that before we merge, the forked view shows the changes but the original view doesn't
+		// Note: to compare tree nodes we have to compare against instances of the schema class, not just POJOs
+		assert.deepEqual(originalView.root, new TestNode({ prop1: 1, prop2: 2 }));
+		assert.deepEqual(forkedView.root, new TestNode({ prop1: 2, prop3: 3 }));
+
+		// Merge and validate that the original view now shows the changes
+		merge(forkedView, originalView);
+		assert.deepEqual(originalView.root, new TestNode({ prop1: 2, prop3: 3 }));
+	});
+});

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -48,8 +48,10 @@ export {
 
 export {
 	type ISharedTree,
+	type ITreeCheckoutFork,
 	type SharedTreeOptions,
 	ForestType,
+	SchematizingSimpleTreeView,
 	type SharedTreeContentSnapshot,
 	type SharedTreeFormatOptions,
 	SharedTreeFormatVersion,
@@ -58,6 +60,7 @@ export {
 	type NodeInDocumentConstraint,
 	type RunTransaction,
 	rollback,
+	getViewForForkedBranch,
 } from "./shared-tree/index.js";
 
 export {

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -33,9 +33,12 @@ export {
 	buildTreeConfiguration,
 } from "./schematizeTree.js";
 
+export { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
+
 export {
 	CheckoutFlexTreeView,
 	type FlexTreeView,
+	getViewForForkedBranch,
 } from "./treeView.js";
 
 export type { ISharedTreeEditor, ISchemaEditor } from "./sharedTreeEditBuilder.js";

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -52,6 +52,7 @@ export const ViewSlot = anchorSlot<TreeView<ImplicitFieldSchema>>();
 
 /**
  * Implementation of TreeView wrapping a FlexTreeView.
+ * @internal
  */
 @breakingClass
 export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitFieldSchema>

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -326,6 +326,8 @@ class Transaction implements ITransaction {
  * Branch (like in a version control system) of SharedTree.
  *
  * {@link ITreeCheckout} that has forked off of the main trunk/branch.
+ *
+ * @internal
  */
 export interface ITreeCheckoutFork extends ITreeCheckout, IDisposable {
 	/**

--- a/packages/dds/tree/src/shared-tree/treeView.ts
+++ b/packages/dds/tree/src/shared-tree/treeView.ts
@@ -12,8 +12,9 @@ import {
 	getTreeContext,
 	type FlexTreeHydratedContext,
 } from "../feature-libraries/index.js";
-import { tryDisposeTreeNode } from "../simple-tree/index.js";
+import { tryDisposeTreeNode, type ImplicitFieldSchema } from "../simple-tree/index.js";
 import { type IDisposable, disposeSymbol } from "../util/index.js";
+import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 
 import type { ITreeCheckout, ITreeCheckoutFork } from "./treeCheckout.js";
 
@@ -96,3 +97,30 @@ export class CheckoutFlexTreeView<out TCheckout extends ITreeCheckout = ITreeChe
  * In practice, this allows the view or checkout to be obtained from a flex node by first getting the context from the flex node and then using this map.
  */
 export const contextToTreeView = new WeakMap<FlexTreeHydratedContext, FlexTreeView>();
+
+
+/**
+ * Creates a branch of the input tree view and returns a new tree view for the branch.
+ *
+ * @remarks To merge the branch back into the original view after applying changes on the branch view, use
+ * `<originalView>.checkout.merge(<branchView>.checkout)`.
+ *
+ * @param originalView - The tree view to branch.
+ * @returns A new tree view for a branch of the input tree view, and an {@link ITreeCheckoutFork} object that can be
+ * used to merge the branch back into the original view.
+ *
+ * @internal
+ */
+export function getViewForForkedBranch<TSchema extends ImplicitFieldSchema>(
+	originalView: SchematizingSimpleTreeView<TSchema>,
+): { forkView: SchematizingSimpleTreeView<TSchema>; forkCheckout: ITreeCheckoutFork } {
+	const forkCheckout = originalView.checkout.fork();
+	return {
+		forkView: new SchematizingSimpleTreeView<TSchema>(
+			forkCheckout,
+			originalView.config,
+			originalView.nodeKeyManager,
+		),
+		forkCheckout,
+	};
+}

--- a/packages/dds/tree/src/test/simple-tree/api/treeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeApi.spec.ts
@@ -25,8 +25,9 @@ import {
 	type TreeNode,
 	TreeViewConfiguration,
 } from "../../../simple-tree/index.js";
+import { getViewForForkedBranch } from "../../../shared-tree/index.js";
 import { getView, validateUsageError } from "../../utils.js";
-import { getViewForForkedBranch, hydrate } from "../utils.js";
+import { hydrate } from "../utils.js";
 import { brand, type areSafelyAssignable, type requireTrue } from "../../../util/index.js";
 
 import {
@@ -806,7 +807,7 @@ describe("treeNodeApi", () => {
 			assert.equal(treeChanged, true, "'treeChanged' should have fired");
 		});
 
-		it(`'nodeChanged' includes the names of changed properties (objectNode)`, () => {
+		it.only(`'nodeChanged' includes the names of changed properties (objectNode)`, () => {
 			const sb = new SchemaFactory("test");
 			class TestNode extends sb.object("root", {
 				prop1: sb.optional(sb.number),

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -147,27 +147,3 @@ export function pretty(arg: unknown): number | string {
 	}
 	return JSON.stringify(arg);
 }
-
-/**
- * Creates a branch of the input tree view and returns a new tree view for the branch.
- *
- * @remarks To merge the branch back into the original view after applying changes on the branch view, use
- * `<originalView>.checkout.merge(<branchView>.checkout)`.
- *
- * @param originalView - The tree view to branch.
- * @returns A new tree view for a branch of the input tree view, and an {@link ITreeCheckoutFork} object that can be
- * used to merge the branch back into the original view.
- */
-export function getViewForForkedBranch<TSchema extends ImplicitFieldSchema>(
-	originalView: SchematizingSimpleTreeView<TSchema>,
-): { forkView: SchematizingSimpleTreeView<TSchema>; forkCheckout: ITreeCheckoutFork } {
-	const forkCheckout = originalView.checkout.fork();
-	return {
-		forkView: new SchematizingSimpleTreeView<TSchema>(
-			forkCheckout,
-			originalView.config,
-			originalView.nodeKeyManager,
-		),
-		forkCheckout,
-	};
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6990,6 +6990,12 @@ importers:
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
+      '@fluidframework/id-compressor':
+        specifier: workspace:~
+        version: link:../../../packages/runtime/id-compressor
+      '@fluidframework/test-runtime-utils':
+        specifier: workspace:~
+        version: link:../../../packages/runtime/test-runtime-utils
       '@fluidframework/tinylicious-client':
         specifier: workspace:~
         version: link:../../../packages/service-clients/tinylicious-client


### PR DESCRIPTION
## Description

Initial draft of exposing a basic branching API in the FluidLLM library.

- Expose a few tree APIs as `@internal`, which required moving the `getViewForForkedBranch` function from test code to source code.
- Add basic `branch()` and `merge()` functions in the FluidLLM library, which operate in terms of existing public SharedTree APIs, so users can actually leverage them in applications today.
- Add a unit test validating that the new functions work as intended in a happy path.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).